### PR TITLE
set stdin_open to true on the frontend service to prevent exit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,4 @@ services:
     depends_on:
       - backend
     command: npm start
+    stdin_open: true


### PR DESCRIPTION
see https://github.com/facebook/create-react-app/issues/8688
this is the best workaround on a dev environment, compared to downgrading react-scripts version and/or setting CI=true